### PR TITLE
Add --repo to the management command; update readme

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,10 @@
-install:
+install: .env
 	@poetry install
+
+.env:
+	@test ! -f .env && cp .env.example .env
+
+setup:
 	@poetry run python manage.py migrate
 	@echo Create a super user
 	@poetry run python manage.py createsuperuser
@@ -27,3 +32,6 @@ start: test
 
 sync:
 	@poetry run python manage.py fetchdata
+
+secretkey:
+	@poetry run python -c 'from django.utils.crypto import get_random_string; print(get_random_string(40))'

--- a/README.md
+++ b/README.md
@@ -3,24 +3,41 @@
 [![Test Coverage](https://api.codeclimate.com/v1/badges/dedb9f8ad241a9152fd0/test_coverage)](https://codeclimate.com/github/Hexlet/hexlet-friends/test_coverage)
 [![wemake-python-styleguide](https://img.shields.io/badge/style-wemake-000000.svg)](https://github.com/wemake-services/wemake-python-styleguide)
 
-# hexlet-friends
+# Hexlet Friends
+Сервис для отслеживания вклада участников сообщества Хекслет в его open-source проекты на GitHub.
 
-Сервис отслеживающий и анализирующий open-source проекты хекслета на github по
-таким параметрам как количество коммитов, pull-реквестов, issues. В результате
-строится leaderboard участников с различными ачивками для мотивации. Сервис
-работает автоматизированно.
+Вклад &mdash; issues, pull requests, commits, comments.
 
-# Как развернуть проект
+## Установка и настройка
 
-```shell script
+### 0. Убедиться, что в системе установлены **poetry** и **make**.
+
+### 1. Выполнить команды:
+
+```
 git clone https://github.com/Hexlet/hexlet-friends
 cd hexlet-friends
-poetry install
-python manage.py migrate
+make install
 ```
 
-```shell script
-python manage.py runserver
-```
+### 2. Задать значения переменным окружения в _.env_:
 
-Проект использует переменные окружения, пример в _.env.example_
+`GITHUB_AUTH_TOKEN` &mdash; Personal access token из [настроек GitHub](https://github.com/settings/tokens).
+
+Значения для `GITHUB_WEBHOOK_TOKEN` и `SECRET_KEY` можно сгенерировать командой `make secretkey`.
+
+`DEBUG=True`
+
+### 3. Выполнить команду `make setup`.
+
+## Запуск сервера для разработки
+
+Выполнить `make start`.
+
+## Локализация текста
+
+Требуется утилита **gettext**.
+
+1. `make transprepare` &mdash; подготовить файл **locale/ru/LC_MESSAGES/django.po**.
+2. Внести изменения в этот файл.
+3. Выполнить `make transcompile`.

--- a/contributors/utils/github_lib.py
+++ b/contributors/utils/github_lib.py
@@ -233,7 +233,7 @@ def get_commit_stats_for_contributor(
     if response.status_code == requests.codes.no_content:
         raise NoContributorsError(
             "Nobody has contributed to this repository yet",
-        )
+        ) from None
 
     try:
         contributor_stats = [
@@ -243,15 +243,17 @@ def get_commit_stats_for_contributor(
     except IndexError:
         raise ContributorNotFoundError(
             "No such contributor in this repository",
-        )
+        ) from None
 
     totals = merge_dicts(*contributor_stats['weeks'])
 
     return totals['c'], totals['a'], totals['d']
 
 
-def get_data_of_orgs_and_repos(org_names=None, repo_full_names=None):
+def get_data_of_orgs_and_repos(*, org_names=None, repo_full_names=None):  # noqa: C901,R701,E501
     """Return data of organizations and their repositories from GitHub."""
+    if not (org_names or repo_full_names):
+        raise ValueError("Neither org_names nor repo_full_names is provided")
     data_of_orgs_and_repos = {}
     with requests.Session() as session:
         if org_names:

--- a/contributors/utils/github_lib.py
+++ b/contributors/utils/github_lib.py
@@ -1,9 +1,9 @@
-from collections import Counter
 from urllib.parse import parse_qs, urlparse
 
 import requests
 from django.conf import settings
-from django.db import models
+
+from contributors.utils.misc import merge_dicts
 
 GITHUB_API_URL = 'https://api.github.com'
 
@@ -222,14 +222,6 @@ def get_pages_count(link_headers):
     return 1
 
 
-def merge_dicts(*dicts):
-    """Merge several dictionaries into one."""
-    counter = Counter()
-    for dict_ in dicts:
-        counter.update(dict_)
-    return counter
-
-
 def get_commit_stats_for_contributor(
     repo_full_name, contributor_id, session=None,
 ):
@@ -258,37 +250,36 @@ def get_commit_stats_for_contributor(
     return totals['c'], totals['a'], totals['d']
 
 
-def get_or_create_record(obj, github_resp, additional_fields=None):   # noqa WPS110
-    """
-    Get or create a database record based on GitHub JSON object.
+def get_data_of_orgs_and_repos(org_names=None, repo_full_names=None):
+    """Return data of organizations and their repositories from GitHub."""
+    data_of_orgs_and_repos = {}
+    with requests.Session() as session:
+        if org_names:
+            for org_name in org_names:
+                data_of_orgs_and_repos[org_name] = {
+                    'details': get_org_data(org_name, session),
+                    'repos': [
+                        repo for repo in get_org_repos(
+                            org_name, session,
+                        )
+                    ],
+                }
+        elif repo_full_names:
+            # Construct a dictionary of names {org: [repo, repo, ...]}
+            names_of_orgs_and_repos = {}
+            for repo_full_name in repo_full_names:
+                org_name, repo_name = repo_full_name.split('/')
+                repos_of_org = names_of_orgs_and_repos.setdefault(org_name, [])
+                repos_of_org.append(repo_name)
 
-    Args:
-        obj -- model or instance of a model
-        github_resp -- GitHub data as a JSON object decoded to dict
-        additional_fields -- fields to override
-    """
-    model_fields = {
-        'Organization': {'name': github_resp.get('login')},
-        'Repository': {'full_name': github_resp.get('full_name')},
-        'Contributor': {
-            'login': github_resp.get('login'),
-            'avatar_url': github_resp.get('avatar_url'),
-        },
-    }
-    defaults = {
-        'name': github_resp.get('name'),
-        'html_url': github_resp.get('html_url'),
-    }
-    if isinstance(obj, models.Model):
-        class_name = obj.repository_set.model.__name__
-        manager = obj.repository_set
-    else:
-        class_name = obj.__name__
-        manager = obj.objects
-
-    defaults.update(model_fields[class_name])
-    defaults.update(additional_fields or {})
-    return manager.get_or_create(
-        id=github_resp['id'],
-        defaults=defaults,
-    )
+            for org_name, repo_names in names_of_orgs_and_repos.items():
+                data_of_orgs_and_repos[org_name] = {
+                    'details': get_org_data(org_name, session),
+                    'repos': [
+                        repo for repo in get_org_repos(
+                            org_name, session,
+                        )
+                        if repo['name'] in repo_names
+                    ],
+                }
+    return data_of_orgs_and_repos

--- a/contributors/utils/misc.py
+++ b/contributors/utils/misc.py
@@ -23,14 +23,15 @@ def merge_dicts(*dicts):
     return counter
 
 
-def get_or_create_record(obj, github_resp, additional_fields=None):   # noqa WPS110
+def get_or_create_record(model, github_resp, additional_fields=None):
     """
     Get or create a database record based on GitHub JSON object.
 
     Args:
-        obj -- model or instance of a model
+        model -- a model or instance of a model
         github_resp -- GitHub data as a JSON object decoded to dict
         additional_fields -- fields to override
+
     """
     model_fields = {
         'Organization': {'name': github_resp.get('login')},
@@ -44,12 +45,14 @@ def get_or_create_record(obj, github_resp, additional_fields=None):   # noqa WPS
         'name': github_resp.get('name'),
         'html_url': github_resp.get('html_url'),
     }
-    if isinstance(obj, models.Model):
-        class_name = obj.repository_set.model.__name__
-        manager = obj.repository_set
+    if isinstance(model, models.Model):
+        class_name = model.repository_set.model.__name__
+        manager = model.repository_set
+    elif issubclass(model, models.Model):
+        class_name = model.__name__
+        manager = model.objects
     else:
-        class_name = obj.__name__
-        manager = obj.objects
+        raise TypeError("Improper type of model")
 
     defaults.update(model_fields[class_name])
     defaults.update(additional_fields or {})

--- a/contributors/utils/misc.py
+++ b/contributors/utils/misc.py
@@ -1,6 +1,8 @@
 import os
+from collections import Counter
 
 from django.core.exceptions import ImproperlyConfigured
+from django.db import models
 
 
 def getenv(env_variable):
@@ -11,3 +13,47 @@ def getenv(env_variable):
         raise ImproperlyConfigured(
             f"The {env_variable} setting must not be empty.",
         )
+
+
+def merge_dicts(*dicts):
+    """Merge several dictionaries into one."""
+    counter = Counter()
+    for dict_ in dicts:
+        counter.update(dict_)
+    return counter
+
+
+def get_or_create_record(obj, github_resp, additional_fields=None):   # noqa WPS110
+    """
+    Get or create a database record based on GitHub JSON object.
+
+    Args:
+        obj -- model or instance of a model
+        github_resp -- GitHub data as a JSON object decoded to dict
+        additional_fields -- fields to override
+    """
+    model_fields = {
+        'Organization': {'name': github_resp.get('login')},
+        'Repository': {'full_name': github_resp.get('full_name')},
+        'Contributor': {
+            'login': github_resp.get('login'),
+            'avatar_url': github_resp.get('avatar_url'),
+        },
+    }
+    defaults = {
+        'name': github_resp.get('name'),
+        'html_url': github_resp.get('html_url'),
+    }
+    if isinstance(obj, models.Model):
+        class_name = obj.repository_set.model.__name__
+        manager = obj.repository_set
+    else:
+        class_name = obj.__name__
+        manager = obj.objects
+
+    defaults.update(model_fields[class_name])
+    defaults.update(additional_fields or {})
+    return manager.get_or_create(
+        id=github_resp['id'],
+        defaults=defaults,
+    )

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,13 +45,17 @@ per-file-ignores =
         # <something> imported but unused
         F401
 
-    contributors/utils/*.py fetchdata.py:
+    github_lib.py, github_webhook.py:
         # Found too many module members
         WPS202,
         # Found line with high Jones Complexity
         WPS221,
         # Found string constant over-use
-        WPS226
+        WPS226,
+        # Found block variables overlap
+        WPS440,
+        # Found control variable used after block
+        WPS441
 
 ignore =
     # Coding magic comment not found


### PR DESCRIPTION
Добавил к команде fetchdata опцию --repo: `manage.py fetchdata --repo org1/repo1 org1/repo2`

Заигнорировал пару предупреждений в конфиге линтера, а то 6 раз _noqa_ указывать не хочется.
Линтер недоволен переиспользованием одного имени в разных блоках, хотя я в каждом блоке эту переменную инициализирую; её переименование здесь не к месту.
> contributors/utils/github_lib.py
>   271:17   WPS440 Found block variables overlap: org_name
>   272:67   WPS441 Found control variable used after block: org_name
>   275:13   WPS440 Found block variables overlap: org_name
>   276:40   WPS441 Found control variable used after block: org_name
>   277:45   WPS441 Found control variable used after block: org_name
>   280:29   WPS441 Found control variable used after block: org_name