### PR TITLE
Slugify URLs and make orgs & repos info updatable

### DIFF
--- a/contributors/management/commands/fetchdata.py
+++ b/contributors/management/commands/fetchdata.py
@@ -55,7 +55,7 @@ def create_contributions(   # noqa: C901,WPS231
             id=contrib[id_field],
             defaults={
                 'repository': repo,
-                'contributor': misc.get_or_create_record(
+                'contributor': misc.update_or_create_record(
                     Contributor, misc.get_contributor_data(
                         contrib_author_login, session,
                     ),
@@ -121,7 +121,7 @@ class Command(management.base.BaseCommand):
             )
 
         for org_data in data_of_orgs_and_repos.values():
-            org, _ = misc.get_or_create_record(
+            org, _ = misc.update_or_create_record(
                 Organization, org_data['details'],
             )
             logger.info(org)
@@ -132,7 +132,7 @@ class Command(management.base.BaseCommand):
             ]
             number_of_repos = len(repos_to_process)
             for i, repo_data in enumerate(repos_to_process, start=1):  # noqa: WPS111,E501
-                repo, _ = misc.get_or_create_record(Repository, repo_data)
+                repo, _ = misc.update_or_create_record(Repository, repo_data)
                 logger.info(f"{repo} ({i}/{number_of_repos})")
                 if repo_data['size'] == 0:
                     logger.info("Empty repository")

--- a/contributors/models/contributor.py
+++ b/contributors/models/contributor.py
@@ -71,4 +71,4 @@ class Contributor(CommonFields):
 
     def get_absolute_url(self):
         """Return the url of an instance."""
-        return reverse('contributors:contributor_details', args=[self.pk])
+        return reverse('contributors:contributor_details', args=[self.login])

--- a/contributors/models/organization.py
+++ b/contributors/models/organization.py
@@ -13,4 +13,4 @@ class Organization(CommonFields):
 
     def get_absolute_url(self):
         """Return the url of an instance."""
-        return reverse('contributors:organization_details', args=[self.pk])
+        return reverse('contributors:organization_details', args=[self.name])

--- a/contributors/models/repository.py
+++ b/contributors/models/repository.py
@@ -37,4 +37,7 @@ class Repository(CommonFields):
 
     def get_absolute_url(self):
         """Return the url of an instance."""
-        return reverse('contributors:repository_details', args=[self.full_name])
+        return reverse(
+            'contributors:repository_details',
+            args=[self.full_name],
+        )

--- a/contributors/models/repository.py
+++ b/contributors/models/repository.py
@@ -37,4 +37,4 @@ class Repository(CommonFields):
 
     def get_absolute_url(self):
         """Return the url of an instance."""
-        return reverse('contributors:repository_details', args=[self.pk])
+        return reverse('contributors:repository_details', args=[self.full_name])

--- a/contributors/signals.py
+++ b/contributors/signals.py
@@ -12,7 +12,7 @@ def handle_user_post_save(sender, **kwargs):
         return
 
     if kwargs['created']:
-        contributor, _ = misc.get_or_create_record(
+        contributor, _ = misc.update_or_create_record(
             apps.get_model('contributors.Contributor'),
             misc.get_contributor_data(site_user.username),
         )

--- a/contributors/urls.py
+++ b/contributors/urls.py
@@ -11,7 +11,7 @@ urlpatterns = [
         name='organizations_list',
     ),
     path(
-        'organizations/<int:pk>',
+        'organizations/<slug:slug>',
         views.organization.OrgRepositoryList.as_view(),
         name='organization_details',
     ),
@@ -21,7 +21,7 @@ urlpatterns = [
         name='repositories_list',
     ),
     path(
-        'repositories/<int:pk>',
+        'repositories/<path:slug>',
         views.repository.RepoContributorList.as_view(),
         name='repository_details',
     ),
@@ -36,7 +36,7 @@ urlpatterns = [
         name='contributors_for_month',
     ),
     path(
-        'contributors/<int:pk>',
+        'contributors/<slug:slug>',
         views.contributor.DetailView.as_view(),
         name='contributor_details',
     ),

--- a/contributors/utils/misc.py
+++ b/contributors/utils/misc.py
@@ -24,9 +24,9 @@ def getenv(env_variable):
         )
 
 
-def get_or_create_record(cls, github_resp, additional_fields=None):
+def update_or_create_record(cls, github_resp, additional_fields=None):
     """
-    Get or create a database record based on GitHub JSON object.
+    Update or create a database record based on a GitHub JSON object.
 
     Args:
         cls -- a class
@@ -52,7 +52,7 @@ def get_or_create_record(cls, github_resp, additional_fields=None):
 
     defaults.update(cls_fields[cls.__name__]())
     defaults.update(additional_fields or {})
-    return cls.objects.get_or_create(
+    return cls.objects.update_or_create(
         id=github_resp['id'],
         defaults=defaults,
     )

--- a/contributors/views/config.py
+++ b/contributors/views/config.py
@@ -29,10 +29,10 @@ def show_repos(request):
             repos_choices = []
             for org_name in form_orgs.cleaned_data['organizations'].split():
                 org_data = github.get_org_data(org_name, session)
-                org, _ = misc.get_or_create_record(Organization, org_data)
+                org, _ = misc.update_or_create_record(Organization, org_data)
                 repos_data = list(github.get_org_repos(org_name, session))
                 for repo_data in repos_data:
-                    misc.get_or_create_record(
+                    misc.update_or_create_record(
                         Repository,
                         repo_data,
                         {'is_tracked': False, 'is_visible': False},

--- a/contributors/views/contributor.py
+++ b/contributors/views/contributor.py
@@ -13,6 +13,7 @@ class DetailView(generic.DetailView):
 
     model = Contributor
     template_name = 'contributor_details.html'
+    slug_field = 'login'
 
     def get_context_data(self, **kwargs):
         """Add additional context for the contributor."""

--- a/contributors/views/organization.py
+++ b/contributors/views/organization.py
@@ -19,7 +19,9 @@ class OrgRepositoryList(repositories.ListView):
 
     def get_queryset(self):
         """Get a dataset."""
-        self.organization = get_object_or_404(Organization, name=self.kwargs['slug'])
+        self.organization = get_object_or_404(
+            Organization, name=self.kwargs['slug'],
+        )
         return super().get_queryset().filter(organization=self.organization)
 
     def get_context_data(self, **kwargs):

--- a/contributors/views/organization.py
+++ b/contributors/views/organization.py
@@ -1,3 +1,4 @@
+from django.shortcuts import get_object_or_404
 from django.utils.translation import gettext_lazy as _
 
 from contributors.models import Organization
@@ -18,7 +19,7 @@ class OrgRepositoryList(repositories.ListView):
 
     def get_queryset(self):
         """Get a dataset."""
-        self.organization = Organization.objects.get(pk=self.kwargs['pk'])
+        self.organization = get_object_or_404(Organization, name=self.kwargs['slug'])
         return super().get_queryset().filter(organization=self.organization)
 
     def get_context_data(self, **kwargs):

--- a/contributors/views/repository.py
+++ b/contributors/views/repository.py
@@ -11,7 +11,9 @@ class RepoContributorList(contributors.ListView):
 
     def get_queryset(self):
         """Get a dataset."""
-        self.repository = get_object_or_404(Repository, full_name=self.kwargs['slug'])
+        self.repository = get_object_or_404(
+            Repository, full_name=self.kwargs['slug'],
+        )
         return self.repository.contributors.visible().with_contributions()
 
     def get_context_data(self, **kwargs):

--- a/contributors/views/repository.py
+++ b/contributors/views/repository.py
@@ -1,3 +1,5 @@
+from django.shortcuts import get_object_or_404
+
 from contributors.models import Repository
 from contributors.views import contributors
 
@@ -9,7 +11,7 @@ class RepoContributorList(contributors.ListView):
 
     def get_queryset(self):
         """Get a dataset."""
-        self.repository = Repository.objects.get(pk=self.kwargs['pk'])
+        self.repository = get_object_or_404(Repository, full_name=self.kwargs['slug'])
         return self.repository.contributors.visible().with_contributions()
 
     def get_context_data(self, **kwargs):


### PR DESCRIPTION
Заменил ID в URL-ах `...organizations/2685047` на имена `...organizations/Hexlet`.
Сделал данные организаций и репозиториев обновляемыми на случай смены имени, например.