### PR TITLE
Fix PR and issues links in contributor profile

### DIFF
--- a/templates/contributor_details.html
+++ b/templates/contributor_details.html
@@ -14,19 +14,13 @@
           <h2 class="h5 card-subtitle font-weight-light">{{ contributor.login }}</h2>
           <a href="{{ contributor.html_url }}" class="card-link badge badge-dark">GitHub</a>
         </div>
+        <nav class="nav">
+          <a class="nav-link" href="{% url 'contributors:contributor_pullrequests' contributor.login %}">
+          {% trans 'Pull requests' %}</a>
+          <a class="nav-link" href="{% url 'contributors:contributor_issues' contributor.login %}">
+          {% trans 'Issues' %}</a>
+        </nav>
       </div>
-    <nav class="navbar navbar-light bg-light">
-      <ul class="navbar-nav mr-auto">
-        <li class="nav-item">
-          <a class="nav-link"
-       href="{% url 'contributors:contributor_pullrequests' contributor.login %}">{% trans 'Pull requests' %}</a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link"
-       href="{% url 'contributors:contributor_issues' contributor.login %}">{% trans 'Issues' %}</a>
-        </li>
-      </ul>
-    </nav>
     </div>
     <div class="col">
       <h2>{% trans "Past year activity" %}</h2>


### PR DESCRIPTION
#154 Переместил меню с ссылками на PR и  issues  в карточку с аватаром.
EN:
![Снимок экрана от 2022-05-25 02-54-34](https://user-images.githubusercontent.com/20521260/170210196-5f7294a8-bf7d-4bcf-a647-40a8b0c64101.png)
RU:
![Снимок экрана от 2022-05-25 02-54-44](https://user-images.githubusercontent.com/20521260/170210238-34d24232-60cc-41cd-989b-e6327eea083d.png)
