### PR TITLE
fix typo in auth/tests.py

### DIFF
--- a/auth/tests.py
+++ b/auth/tests.py
@@ -28,7 +28,7 @@ class RegistrationPageViewTest(TestCase):
         self._assert_email(form_fields, response)
         self._assert_username(form_fields, response)
         self._assert_password(form_fields, response)
-        self._assert_password_confiramtion(form_fields, response)
+        self._assert_password_confirmation(form_fields, response)
 
     def _assert_email(self, form_fields, response):
         self.assertIn(

--- a/auth/tests.py
+++ b/auth/tests.py
@@ -60,7 +60,7 @@ class RegistrationPageViewTest(TestCase):
             response.rendered_content,
         )
 
-    def _assert_password_confiramtion(self, form_fields, response):
+    def _assert_password_confirmation(self, form_fields, response):
         self.assertIn(
             str(form_fields['password2'].label),
             response.rendered_content,


### PR DESCRIPTION
Fix typo in auth/tests.py (function _assert_password_confirmation) Related to #170