### PR TITLE
fix get contributor data

### DIFF
--- a/contributors/utils/misc.py
+++ b/contributors/utils/misc.py
@@ -72,7 +72,7 @@ def get_contributor_data(login, session=None):
     try:
         user = Contributor.objects.get(login=login)
     except Contributor.DoesNotExist:
-        return github.get_user_data(login, session)
+        return github.get_owner_data(login, session)
     return {
         'id': user.id,
         'name': user.name,


### PR DESCRIPTION
Дополнение к PR #191.
Пропустил переименование функции `get_user_data` в `get_contributor_data` из-за чего происходит ошибка при попытки получить данные.