### PR TITLE
Rename dropdown item #232

### DIFF
--- a/templates/components/navbar.html
+++ b/templates/components/navbar.html
@@ -27,7 +27,7 @@
             {% trans "Contributors" %}
           </a>
           <div class="dropdown-menu">
-            <a class="dropdown-item" href="{% url 'contributors:contributors_for_month' %}">{% trans "For month" %}</a>
+            <a class="dropdown-item" href="{% url 'contributors:contributors_for_month' %}">{% trans "For period" %}</a>
             <a class="dropdown-item" href="{% url 'contributors:contributors_list' %}">{% trans "All-time" %}</a>
           </div>
         </li>


### PR DESCRIPTION
Slightly changes have been made to 'navbar.html'.
Label "For month" in dropdown item in contributors menu change to "For period".

issue: [Rename dropdown item #232](https://github.com/Hexlet/hexlet-friends/issues/232)