### PR TITLE
Add_separation_into_PR_and_issues_on_the_main_page

### DIFF
--- a/contributors/views/home.py
+++ b/contributors/views/home.py
@@ -1,8 +1,9 @@
 from django.views.generic.base import TemplateView
 
 from contributors.models import Contribution, Contributor
+from contributors.utils.misc import datetime_month_ago, datetime_week_ago
 
-LATEST_ISSUES_COUNT = 11
+LATEST_ISSUES_COUNT = 10
 
 
 def get_top10(dataset, contrib_type):
@@ -52,10 +53,29 @@ class HomeView(TemplateView):
             contributors_for_week, 'comments',
         )
 
-        latest_issues = Contribution.objects.filter(
+        latest_month_issues = Contribution.objects.filter(
             repository__is_visible=True,
-            type__in=['pr', 'iss'],
-        ).order_by('-created_at')[:LATEST_ISSUES_COUNT]
+            type='iss',
+            created_at__gte=datetime_month_ago(),
+        ).distinct().order_by('-created_at')[:LATEST_ISSUES_COUNT]
+
+        latest_week_issues = Contribution.objects.filter(
+            repository__is_visible=True,
+            type='iss',
+            created_at__gte=datetime_week_ago(),
+        ).distinct().order_by('-created_at')[:LATEST_ISSUES_COUNT]
+
+        latest_month_pr = Contribution.objects.filter(
+            repository__is_visible=True,
+            type='pr',
+            created_at__gte=datetime_month_ago(),
+        ).distinct().order_by('-created_at')[:LATEST_ISSUES_COUNT]
+
+        latest_week_pr = Contribution.objects.filter(
+            repository__is_visible=True,
+            type='pr',
+            created_at__gte=datetime_week_ago(),
+        ).distinct().order_by('-created_at')[:LATEST_ISSUES_COUNT]
 
         context.update(
             {
@@ -69,7 +89,10 @@ class HomeView(TemplateView):
                 'top10_reporters_of_week': top10_reporters_of_week,
                 'top10_commentators_of_week': top10_commentators_of_week,
                 'contributions_for_year': Contribution.objects.for_year(),
-                'latest_issues': latest_issues,
+                'latest_month_issues': latest_month_issues,
+                'latest_week_issues': latest_week_issues,
+                'latest_month_pr': latest_month_pr,
+                'latest_week_pr': latest_week_pr,
             },
         )
 

--- a/static/css/base.css
+++ b/static/css/base.css
@@ -63,8 +63,16 @@ main {
   margin-right: 1.7em;
 }
 
-.latest-issues-heading {
-  margin-bottom: 3.0rem;
+.issues-and-pr-time-note {
+  display: inline-block;
+  cursor: default;
+  border-bottom-style: dotted;
+  border-bottom-width: 1px;
+  margin-bottom: 8px;
+}
+
+.issues-and-pr-time-note:hover {
+  text-decoration: none;
 }
 
 @media (max-width: 768px) {

--- a/static/js/issues_and_pr.js
+++ b/static/js/issues_and_pr.js
@@ -1,0 +1,37 @@
+function issues_and_pr_grouping(time_group) {
+  const tops = document.querySelector(`.${time_group}`);
+  const tabs = tops.querySelectorAll('.nav-link');
+  tabs.forEach((tab) => tab.addEventListener('click', (e) => {
+    e.preventDefault();
+    const activeTab = tops.querySelector('.nav-link.active');
+    const activeList = tops.querySelector(`.list-group.${activeTab.name}`);
+    activeTab.classList.remove('active');
+    activeList.classList.add('d-none');
+
+    const newActiveTab = e.target;
+    const newActiveList = tops.querySelector(`.list-group.${newActiveTab.name}`);
+    newActiveTab.classList.add('active');
+    newActiveList.classList.remove('d-none');
+  }));
+}
+
+function issues_time_note_executor() {
+  const tops = document.querySelector('.latest-issues');
+  const tabs = tops.querySelectorAll('.issues-and-pr-time-note');
+  tabs.forEach((tab) => tab.addEventListener('click', (e) => {
+    e.preventDefault();
+    const activeTab = tops.querySelector('.issues-and-pr-time-note.active');
+    const activeList = tops.querySelector(`.latest-issues-and-pr.${activeTab.name}`);
+    activeTab.classList.remove('active');
+    activeList.classList.add('d-none');
+
+    const newActiveTab = e.target;
+    const newActiveList = tops.querySelector(`.latest-issues-and-pr.${newActiveTab.name}`);
+    newActiveTab.classList.add('active');
+    newActiveList.classList.remove('d-none');
+    start(newActiveTab.name)
+  }));
+}
+
+document.addEventListener('DOMContentLoaded', issues_and_pr_grouping('issues-and-pr-for-week'));
+document.addEventListener('DOMContentLoaded', issues_time_note_executor);

--- a/templates/components/issues_and_pr_for_month.html
+++ b/templates/components/issues_and_pr_for_month.html
@@ -1,0 +1,18 @@
+{% load i18n %}
+
+<div class="card latest-issues-and-pr issues-and-pr-for-month d-none">
+    <div class="card-header">
+      <ul class="nav nav-tabs card-header-tabs">
+        <li class="nav-item">
+          <a class="nav-link px-2 active" name="pull-requests" href="#">{% trans 'by pull requests' %}</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link px-2" name="issues" href="#">{% trans 'by issues' %}</a>
+        </li>
+      </ul>
+    </div>
+    {% with tab='components/top_issues.html' %}
+      {% include tab with latest_issues=latest_month_pr class='pull-requests' %}
+      {% include tab with latest_issues=latest_month_issues class='issues' %}
+    {% endwith %}
+</div>

--- a/templates/components/issues_and_pr_for_week.html
+++ b/templates/components/issues_and_pr_for_week.html
@@ -1,0 +1,18 @@
+{% load i18n %}
+
+<div class="card latest-issues-and-pr issues-and-pr-for-week">
+    <div class="card-header">
+      <ul class="nav nav-tabs card-header-tabs">
+        <li class="nav-item">
+          <a class="nav-link px-2 active" name="pull-requests" href="#">{% trans 'by pull requests' %}</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link px-2" name="issues" href="#">{% trans 'by issues' %}</a>
+        </li>
+      </ul>
+    </div>
+    {% with tab='components/top_issues.html' %}
+      {% include tab with latest_issues=latest_week_pr class='pull-requests' %}
+      {% include tab with latest_issues=latest_week_issues class='issues' %}
+    {% endwith %}
+</div>

--- a/templates/components/time_note_for_issues_and_pr.html
+++ b/templates/components/time_note_for_issues_and_pr.html
@@ -1,0 +1,16 @@
+{% load i18n %}
+
+<ul class="nav nav-pills">
+  <li class="nav-item">
+    <a class="nav-link issues-and-pr-time-note py-1 active" href="#"
+       name="issues-and-pr-for-week">
+      {% trans "for the past week" %}
+    </a>
+  </li>
+  <li class="nav-item">
+    <a class="nav-link issues-and-pr-time-note py-1" href="#"
+       name="issues-and-pr-for-month">
+      {% trans "for the past month" %}
+    </a>
+  </li>
+</ul>

--- a/templates/components/top_issues.html
+++ b/templates/components/top_issues.html
@@ -1,0 +1,15 @@
+{% load i18n static %}
+
+<ul class="list-group list-group-flush {{ class }} {% if class != 'pull-requests' %}d-none{% endif %}">
+  {% for issue in latest_issues %}
+    <li class="list-group-item text-truncate">
+      {% if issue.type == 'iss' %}
+        <img src="{% static 'images/github_icons/issue-opened.svg' %}" alt="Issue">
+      {% elif issue.type == 'pr' %}
+        <img src="{% static 'images/github_icons/git-pull-request.svg' %}" alt="PR">
+      {% endif %}
+      <a href="{{ issue.repository.get_absolute_url }}">{{ issue.repository }}</a>:
+      <a href="{{ issue.html_url }}" target="_blank">{{ issue.info.title }}</a>
+    </li>
+  {% endfor %}
+</ul>

--- a/templates/home.html
+++ b/templates/home.html
@@ -19,24 +19,15 @@
     </div>
     <div class="col-md-6">
       <h2 class="latest-issues-heading">{% trans "New PRs and issues" %}</h2>
-      <div class="card latest-issues">
-        <ul class="list-group list-group-flush">
-          {% for issue in latest_issues %}
-            <li class="list-group-item text-truncate">
-              {% if issue.type == 'iss' %}
-                <img src="{% static 'images/github_icons/issue-opened.svg' %}" alt="Issue">
-              {% elif issue.type == 'pr' %}
-                <img src="{% static 'images/github_icons/git-pull-request.svg' %}" alt="PR">
-              {% endif %}
-              <a href="{{ issue.repository.get_absolute_url }}">{{ issue.repository }}</a>:
-              <a href="{{ issue.html_url }}" target="_blank">{{ issue.info.title }}</a>
-            </li>
-          {% endfor %}
-        </ul>
+      <div class="latest-issues">
+        {% include 'components/time_note_for_issues_and_pr.html' %}
+        {% include 'components/issues_and_pr_for_week.html' %}
+        {% include 'components/issues_and_pr_for_month.html' %}
       </div>
     </div>
   </div>
 {% endblock content %}
 {% block body_end_scripts %}
   <script src="{% static 'js/top10Contributors.js' %}"></script>
+  <script src="{% static 'js/issues_and_pr.js' %}"></script>
 {% endblock %}


### PR DESCRIPTION
Added split it into two tabs: PR and Issues. 
Added buttons: "for the past week", "for the past month"
Added tabs: "PR" and "Issues"

It may be necessary to edit the "IssueInfo" model in order to remove duplication in the file: 
contributors/views/home.py? If it needed, is it possible to open a new issue?
