### PR TITLE
bump codeclimate-action version

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -30,7 +30,7 @@ jobs:
           GITHUB_WEBHOOK_TOKEN: secret
           DB_ENGINE: SQLite
       - name: Publish code coverage report
-        uses: paambaati/codeclimate-action@v2.6.0
+        uses: paambaati/codeclimate-action@v4.0.0
         env:
           CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
         with:


### PR DESCRIPTION
Our ci experiencing some trouble with codeclimate-action. 

There are message in developer repo - Please upgrade to v3.1.1 (or higher) immediately. 
Lower versions can be broken.