### PR TITLE
fix(docker-compose): fix file name typo

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
   django:
     build:
       context: .
-      dockerfile: dockerfile.dev
+      dockerfile: Dockerfile.dev
     environment:
       - DEBUG=True
     env_file:


### PR DESCRIPTION
Не работала сборка через docker из-за опечатки:  в репозитории файл "Dockerfile.dev", а в файле docker-compose.yml он указан как "dockerfile.dev".