### PR TITLE
fix: add default values into pull_requests page

### DIFF
--- a/templates/components/tables/pull_requests_list.html
+++ b/templates/components/tables/pull_requests_list.html
@@ -31,14 +31,16 @@
     <tr>
       <th scope="row">{{ pr.num }}</th>
       <td class="col-3">
-        <a href="{{ pr.html_url }}">{{ pr.info.title }}</a>
+        {% with "Pull request #"|add:pr.id as default_value %}
+          <a href="{{ pr.html_url }}">{{ pr.info.title|default:default_value }}</a>
+        {% endwith %}
       </td>
       <td class="col-3">{{ pr.repository.full_name }}</td>
       <td class="col-2">
         <a href="{% url 'contributors:contributor_details' pr.contributor.login %}">{{ pr.contributor.login }}</a>
       </td>
       <td class="col-2">{{ pr.created_at|date:"d.m.Y" }}</td>
-      <td class="col">{{ pr.info.state|capfirst }}</td>
+      <td class="col">{{ pr.info.state|default:"open"|capfirst }}</td>
     </tr>
   {% empty %}
     <tr>


### PR DESCRIPTION
Добавлены два значения по умолчанию для страницы с [pull requests](https://friends.hexlet.io/pull_requests):
1. Для поля Title/Название дефолтное значение `'Pull request #' + id`
2. Для поля Status/Статус дефолтное значение `Open`

Насчет дефолтного значения статуса были сомнения, но так как большинство забагованных pull requests были открытыми, оставила этот вариант. Его можно исправить на `Closed` или `Archived`/`Undefined`, но здесь тоже свои плюсы и минусы.

Issue #340 