### PR TITLE
[#266] Add issue filtering by status

### DIFF
--- a/contributors/views/filters.py
+++ b/contributors/views/filters.py
@@ -37,7 +37,7 @@ class IssuesFilter(django_filters.FilterSet):
         lookup_expr='icontains',
         field_name='info__state',
         label='',
-        empty_label=_('All'),
+        empty_label=_('Status'),
     )
 
     good_first_issue_filter = django_filters.BooleanFilter(

--- a/contributors/views/filters.py
+++ b/contributors/views/filters.py
@@ -5,9 +5,14 @@ from django.utils.translation import gettext_lazy as _
 
 from contributors.models import Contribution, ContributionLabel
 
+STATE_CHOICES = (
+    ('open', _('Open')),
+    ('closed', _('Closed')),
+)
+
 
 class IssuesFilter(django_filters.FilterSet):
-    """Open issues filter."""
+    """Issues filter."""
 
     info_title = django_filters.CharFilter(
         field_name='info__title',
@@ -27,6 +32,14 @@ class IssuesFilter(django_filters.FilterSet):
         label='',
         widget=TextInput(attrs={'placeholder': _('Language')}),
     )
+    info_state = django_filters.ChoiceFilter(
+        choices=STATE_CHOICES,
+        lookup_expr='icontains',
+        field_name='info__state',
+        label='',
+        empty_label=_('All'),
+    )
+
     good_first_issue_filter = django_filters.BooleanFilter(
         field_name='good_first_issue',
         method='get_good_first_issue',
@@ -40,10 +53,11 @@ class IssuesFilter(django_filters.FilterSet):
             'info_title',
             'repository_full_name',
             'repository_labels',
+            'info_state',
         ]
 
     def get_good_first_issue(self, queryset, name, value):  # noqa: WPS110
-        """Filter open issues by label 'good_first_issue'."""
+        """Filter issues by label 'good_first_issue'."""
         good_first = ContributionLabel.objects.filter(
             name='good first issue',
         ).first()

--- a/contributors/views/issues.py
+++ b/contributors/views/issues.py
@@ -48,7 +48,7 @@ class ListView(
     def get_context_data(self, *args, **kwargs):
         """Add context."""
         all_contribution_id = Contribution.objects.filter(
-            type='iss'
+            type='iss',
         ).values_list('id', flat=True).distinct()
         all_contribution_labels = ContributionLabel.objects.filter(
             contribution__id__in=all_contribution_id,

--- a/contributors/views/issues.py
+++ b/contributors/views/issues.py
@@ -14,7 +14,7 @@ class ListView(
     TableSortSearchAndPaginationMixin,
     FilterView,
 ):
-    """A list of opened issues."""
+    """A list of issues."""
 
     template_name = 'open_issues.html'
     filterset_class = IssuesFilter
@@ -39,7 +39,7 @@ class ListView(
     )
 
     queryset = (
-        Contribution.objects.filter(type='iss', info__state='open').
+        Contribution.objects.filter(type='iss').
         select_related('repository', 'contributor', 'info').
         prefetch_related("repository__labels", contributionlabel_prefetch).
         distinct()
@@ -48,7 +48,7 @@ class ListView(
     def get_context_data(self, *args, **kwargs):
         """Add context."""
         all_contribution_id = Contribution.objects.filter(
-            type='iss', info__state='open',
+            type='iss'
         ).values_list('id', flat=True).distinct()
         all_contribution_labels = ContributionLabel.objects.filter(
             contribution__id__in=all_contribution_id,

--- a/templates/components/issues_filter.html
+++ b/templates/components/issues_filter.html
@@ -13,6 +13,9 @@
      <div class="col">
       {{ filter.form.repository_labels|as_crispy_field }}
      </div> 
+     <div class="col">
+      {{ filter.form.info_state|as_crispy_field }}
+     </div>
      <div class="form-group">
       {{ filter.form.good_first_issue_filter|as_crispy_field }}
      </div>

--- a/templates/components/navbar.html
+++ b/templates/components/navbar.html
@@ -40,7 +40,7 @@
         </li>
         <li class="nav-item">
           <a class="nav-link" href="{% url 'contributors:open_issues' %}">
-            {% trans "Open Issues" %}
+            {% trans "Issues" %}
           </a>
         </li>
         <li class="nav-item">

--- a/templates/open_issues.html
+++ b/templates/open_issues.html
@@ -1,10 +1,10 @@
 {% extends 'base.html' %}
 {% load i18n %}
-{% block title %}{% trans "Open Issues" %}{% endblock %}
+{% block title %}{% trans "Issues" %}{% endblock %}
 <!-- Open Graph tags -->
-{% block og_title %}{% trans "Open Issues" %}{% endblock og_title %}
+{% block og_title %}{% trans "Issues" %}{% endblock og_title %}
 <!-- End Open Graph tags -->
-{% block header %}{% trans "Open Issues" %}{% endblock header %}
+{% block header %}{% trans "Issues" %}{% endblock header %}
 {% block content %}
   {% include 'components/issues_filter.html' %}
   {% include 'components/issue_tags_list.html' %}


### PR DESCRIPTION
Add issue filtering by status to view issues.
Rename the page title "Open Issues" to "Issues".
Update navigation.