### PR TITLE
[#294] Fix: label filter color & Feat: filter reset button

### DIFF
--- a/templates/components/issue_tags_list.html
+++ b/templates/components/issue_tags_list.html
@@ -4,7 +4,7 @@
     {% for label in all_contribution_labels %}
         <a href="{% url 'contributors:open_issues' %}{% get_contribution_label_query_string label|lower %}"
            class="text-decoration-none">
-            <span class="badge bg-primary {% if label not in contribution_labels %} bg-secondary {% endif %}">{{ label }}</span>
+						<span class="badge {% if label not in contribution_labels %}bg-primary{% else %}bg-secondary{% endif %}">{{ label }}</span>
         </a>
     {% endfor %}
 </div>

--- a/templates/components/issue_tags_list.html
+++ b/templates/components/issue_tags_list.html
@@ -4,7 +4,12 @@
     {% for label in all_contribution_labels %}
         <a href="{% url 'contributors:open_issues' %}{% get_contribution_label_query_string label|lower %}"
            class="text-decoration-none">
-						<span class="badge {% if label not in contribution_labels %}bg-primary{% else %}bg-secondary{% endif %}">{{ label }}</span>
+						<span class="badge {% if label not in contribution_labels %}bg-success{% else %}bg-secondary{% endif %}">{{ label }}</span>
         </a>
     {% endfor %}
+</div>
+<div>
+	<a href="{% url 'contributors:open_issues' %}">
+		<span class="btn btn-outline-danger">Reset</span>
+	</a>
 </div>

--- a/templates/components/tables/open_issues_list.html
+++ b/templates/components/tables/open_issues_list.html
@@ -49,7 +49,7 @@
         {% for label in issue.labels.all %}
         <a href="{% url 'contributors:open_issues' %}{% get_contribution_label_query_string label|lower %}"
         class="text-decoration-none">
-        <span class="badge bg-primary {% if label not in contribution_labels %} bg-secondary {% endif %}">{{ label }}</span></a>
+					<span class="badge {% if label not in contribution_labels %}bg-primary{% else %}bg-secondary{% endif %}">{{ label }}</span></a>
         {% endfor %}
       </td>
     </tr>

--- a/templates/components/tables/open_issues_list.html
+++ b/templates/components/tables/open_issues_list.html
@@ -49,7 +49,7 @@
         {% for label in issue.labels.all %}
         <a href="{% url 'contributors:open_issues' %}{% get_contribution_label_query_string label|lower %}"
         class="text-decoration-none">
-					<span class="badge {% if label not in contribution_labels %}bg-primary{% else %}bg-secondary{% endif %}">{{ label }}</span></a>
+					<span class="badge {% if label not in contribution_labels %}bg-success{% else %}bg-secondary{% endif %}">{{ label }}</span></a>
         {% endfor %}
       </td>
     </tr>


### PR DESCRIPTION
Пофиксил отображение цветов для issues label фильтров.
Не активный - серый цвет.
После активации зелёный.

Так же добавил кнопку для сброса фильтров, перенаправляет на /issues/.

Issue #294 