### PR TITLE
Update .gitignore: exclude vim temp files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,8 @@ htmlcov/
 *.sqlite3
 *.bak
 *.mo
+*.swp
+*.swo
+*.swn
 .coverage
 env/


### PR DESCRIPTION
Добавил исключение временных файлов vim.
Расширения:
*.swp
*.swo
*.swn

Актуально использующим vim для разработки.