### PR TITLE
[#425] Fix filter for "issues" page

### DIFF
--- a/contributors/views/filters.py
+++ b/contributors/views/filters.py
@@ -67,18 +67,14 @@ class IssuesFilter(django_filters.FilterSet):
 
     def get_good_first_issue(self, queryset, name, value):  # noqa: WPS110
         """Filter issues by label 'good_first_issue'."""
-        good_first = ContributionLabel.objects.filter(
-            name='good first issue',
-        ).first()
-        all_open_issues = Contribution.objects.filter(
-            type='iss', info__state='open',
-        )
-        if good_first is None:
-            queryset = all_open_issues.none()
-        elif value:
-            queryset = all_open_issues.filter(
-                labels__in=[good_first.id],
-            )
+        if value:  # Only apply filter if checkbox is checked
+            good_first = ContributionLabel.objects.filter(
+                name='good first issue',
+            ).first()
+            if good_first:
+                queryset = queryset.filter(
+                    labels__in=[good_first.id], info__state='open',
+                )
         return queryset
 
 


### PR DESCRIPTION
Переделал метод get_good_first_issue для фильтра IssuesFilter.

В текущем варианте queryset, передаваемый в метод, не используется, создаётся новый. Что сбрасывает фильтрацию по имени репозитория.

Переделанный вариант метода get_good_first_issue работает с переданным ему queryset, изменяет его,  и возвращает.

[Демо](https://hexlet-friends-bepe.onrender.com/issues/?info_title=&repository_full_name=Hexlet%2Fhexlet-sicp&repository_labels=&info_state=&good_first_issue_filter=on) выложил. Описание демо, в топике issue.